### PR TITLE
Update btcec/btcnet imports to new locations

### DIFF
--- a/datainput.go
+++ b/datainput.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/btcsuite/btcec"
+	"github.com/btcsuite/btcd/btcec"
 )
 
 // readLength is the length of a hash compression read in bytes.

--- a/messagesign.go
+++ b/messagesign.go
@@ -14,8 +14,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/btcsuite/btcec"
-	"github.com/btcsuite/btcnet"
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil"
 )
 
@@ -62,7 +62,7 @@ func generateKeyPair(filename string) error {
 
 	// Store the address in case anyone wants to use it for BTC
 	pkh, err := btcutil.NewAddressPubKey(pubkeyBtcec.SerializeCompressed(),
-		&btcnet.MainNetParams)
+		&chaincfg.MainNetParams)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Those repositories moved to new locations on github.com.